### PR TITLE
Add Searchspring packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # template-ts
 Template Typescript repo
+
+## Includes
+
+- Prettier config from [`@searchspring/prettier`](https://github.com/searchspring/prettier)
+- ESLint config from [`@searchspring/eslint-config`](https://github.com/searchspring/eslint-config)
+- Commitlint [`@searchspring/commitlint-config`](https://github.com/searchspring/commitlint-config)
+
+Checkout the `package.json` for `scripts`.


### PR DESCRIPTION
List included Searchspring packages. Make README consistent with existing template-js README.